### PR TITLE
chore: use rpc url env

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,4 +4,4 @@ out = 'out'
 libs = ['lib']
 
 [rpc_endpoints]
-paradigm = "INSERT"
+paradigm = "${PARADIGM_RPC_URL}"


### PR DESCRIPTION
Can use env vars in `[rpc_endpoints]` :detective:  https://book.getfoundry.sh/reference/config#rpc_endpoints